### PR TITLE
updated levy template ratios

### DIFF
--- a/common/levy_templates/01_anatolian.txt
+++ b/common/levy_templates/01_anatolian.txt
@@ -8,32 +8,32 @@
 levy_anatolian = {	#General Anatolian
 	default = no
 
-	light_infantry = 0.4
+	light_infantry = 0.6
 	light_cavalry = 0.3
-	heavy_cavalry = 0.3
+	heavy_cavalry = 0.1
 }
 
 levy_armenian = {	#Armenians
 	default = no
 
 	light_infantry = 0.7
-	horse_archers = 0.15
-	heavy_cavalry = 0.15
+	horse_archers = 0.2
+	heavy_cavalry = 0.1
 }
 
 levy_pontus = {	#Pontus
 	default = no
 
-	archers = 0.3
-	light_infantry = 0.4	
-	heavy_cavalry = 0.3
+	archers = 0.4
+	light_infantry = 0.5
+	heavy_cavalry = 0.1
 }
 
 levy_cappadocia = {	#Cappadocia
 	default = no
 
-	light_infantry = 0.4
-	heavy_cavalry = 0.3
+	light_infantry = 0.6
+	heavy_cavalry = 0.1
 	light_cavalry = 0.3
 }
 

--- a/common/levy_templates/01_bactrian.txt
+++ b/common/levy_templates/01_bactrian.txt
@@ -7,10 +7,10 @@
 
 levy_bactrian = {
 	default = no
-	
+
 	archers = 0.7
-	warelephant = 0.15
-	horse_archers = 0.15
+	warelephant = 0.05
+	horse_archers = 0.25
 }
 
 levy_central_asia = {

--- a/common/levy_templates/01_caucasian.txt
+++ b/common/levy_templates/01_caucasian.txt
@@ -5,12 +5,12 @@
 #	3rd NOTE: If a specific subunit cannot be constructed for some reason another one that can from that tier will replace it ( if possible )
 #
 
-levy_caucasian = {	#Iberia, Kartli & Colchis 
+levy_caucasian = {	#Iberia, Kartli & Colchis
 	default = no
 
-	light_infantry = 0.4	
+	light_infantry = 0.6
 	light_cavalry = 0.3
-	heavy_cavalry = 0.3
+	heavy_cavalry = 0.1
 }
 
 levy_albanian = {

--- a/common/levy_templates/01_celtic.txt
+++ b/common/levy_templates/01_celtic.txt
@@ -8,7 +8,7 @@
 levy_gallic = {
 	default = no
 
-	archers = 0.4	
+	archers = 0.4
 	heavy_infantry = 0.3
 	light_cavalry = 0.3
 }
@@ -23,7 +23,7 @@ levy_italian_gallic = {
 
 levy_northern_gallic = {
 	default = no
-	
+
 	light_infantry = 0.4
 	light_cavalry = 0.3
 	heavy_infantry = 0.3
@@ -34,7 +34,7 @@ levy_gallic_panonian = {
 
 	light_infantry = 0.5
 	light_cavalry = 0.2
-	heavy_infantry = 0.2
+	heavy_infantry = 0.3
 }
 
 levy_norican = {
@@ -55,8 +55,8 @@ levy_britannic = {
 
 levy_celtiberian = {
 	default = no
-	
+
 	light_infantry = 0.4
-	heavy_infantry = 0.3	
+	heavy_infantry = 0.3
 	light_cavalry = 0.3
 }

--- a/common/levy_templates/01_east_levantine.txt
+++ b/common/levy_templates/01_east_levantine.txt
@@ -8,17 +8,17 @@
 levy_east_levantine = {	#Mesopotamian states
 	default = no
 
-	light_infantry = 0.45
-	light_cavalry = 0.25
+	light_infantry = 0.6
+	light_cavalry = 0.3
 
-	heavy_cavalry = 0.3
+	heavy_cavalry = 0.1
 }
 
 levy_babylonian = {	#Babylonian states
 	default = no
 
-	archers = 0.45
-	light_cavalry = 0.25
+	archers = 0.6
+	light_cavalry = 0.3
 
-	heavy_cavalry = 0.3
+	heavy_cavalry = 0.1
 }

--- a/common/levy_templates/01_egyptiannubian.txt
+++ b/common/levy_templates/01_egyptiannubian.txt
@@ -32,7 +32,7 @@ levy_blemmyan = {	#Blemmyan
 levy_ethiopian = {	#Axumite
 	default = no
 
-	light_infantry = 0.3
-	heavy_cavalry = 0.3
-	camels = 0.4
+	light_infantry = 0.6
+	heavy_cavalry = 0.1
+	camels = 0.3
 }

--- a/common/levy_templates/01_hellenic.txt
+++ b/common/levy_templates/01_hellenic.txt
@@ -15,7 +15,7 @@ levy_general_greek = {	#Poleis with Hoplites
 
 levy_cretan = {
 	default = no
-	
+
 	#Basic:
 	archers = 0.6
 	#Advanced:
@@ -25,7 +25,7 @@ levy_cretan = {
 
 levy_macedonian = {
 	default = no
-	
+
 	light_infantry = 0.4
 	heavy_infantry = 0.3
 	light_cavalry = 0.3
@@ -34,7 +34,7 @@ levy_macedonian = {
 
 levy_magna_graecia = {
 	default = no
-	
+
 	light_infantry = 0.5
 	heavy_infantry = 0.3
 	light_cavalry = 0.2
@@ -42,7 +42,7 @@ levy_magna_graecia = {
 
 levy_spartan = {
 	default = no
-	
+
 	light_infantry = 0.5
 	heavy_infantry = 0.4
 	light_cavalry = 0.1
@@ -50,7 +50,7 @@ levy_spartan = {
 
 levy_argolis = {
 	default = no
-	
+
 	light_infantry = 0.5
 	heavy_infantry = 0.3
 	light_cavalry = 0.2
@@ -58,18 +58,18 @@ levy_argolis = {
 
 levy_thessalian = {
 	default = no
-	
-	light_infantry = 0.45
-	heavy_cavalry = 0.3
-	light_cavalry = 0.25
+
+	light_infantry = 0.6
+	heavy_cavalry = 0.1
+	light_cavalry = 0.3
 }
 
 levy_cyrene = {
 	default = no
 
-	light_infantry = 0.7
-	heavy_infantry = 0.15
-	camels = 0.15
+	light_infantry = 0.4
+	heavy_infantry = 0.3
+	camels = 0.3
 }
 
 levy_bosporan_greek = {

--- a/common/levy_templates/01_indian.txt
+++ b/common/levy_templates/01_indian.txt
@@ -8,24 +8,24 @@
 levy_northwestern_indian = {
 	default = no
 
-	light_infantry = 0.3
-	archers = 0.4
-	warelephant = 0.3
+	light_infantry = 0.4
+	archers = 0.55
+	warelephant = 0.05
 }
 
 levy_sindhi = {
 	default = no
 
-	archers = 0.4
-	light_cavalry = 0.3
+	archers = 0.6
+	heavy_cavalry = 0.1
 	camels = 0.3
 }
 
 levy_gandhari = {
 	default = no
 
-	light_infantry = 0.4
-	warelephant = 0.3
+	light_infantry = 0.65
+	warelephant = 0.05
 	light_cavalry = 0.3
 }
 
@@ -40,15 +40,15 @@ levy_northeastern_indian = {
 levy_jungle_indian = {
 	default = no
 
-	archers = 0.3
-	light_infantry = 0.4
-	warelephant = 0.3
+	archers = 0.4
+	light_infantry = 0.55
+	warelephant = 0.05
 }
 
 levy_southern_indian = {
 	default = no
 
-	light_infantry = 0.35
-	archers = 0.35
-	warelephant = 0.3
+	archers = 0.5
+	light_infantry = 0.45
+	warelephant = 0.05
 }

--- a/common/levy_templates/01_iranian.txt
+++ b/common/levy_templates/01_iranian.txt
@@ -8,34 +8,34 @@
 levy_iran = {
 	default = no
 
-	archers = 0.2
-	heavy_cavalry = 0.3
-	light_cavalry = 0.5
+	archers = 0.6
+	heavy_cavalry = 0.1
+	light_cavalry = 0.3
 }
 
 levy_parthian = {
 	default = no
 
-	archers = 0.35
-	light_cavalry = 0.35
-	horse_archers = 0.3	
+	archers = 0.6
+	heavy_cavalry = 0.1
+	horse_archers = 0.3
 }
 
 
 levy_cadusian = {
 	default = no
 
-	archers = 0.4
-	light_infantry = 0.3	
-	heavy_cavalry = 0.3
+	archers = 0.5
+	light_infantry = 0.4
+	heavy_cavalry = 0.1
 }
 
 
 levy_carmanian = {
 	default = no
 
-	archers = 0.3
-	light_infantry = 0.4
+	archers = 0.4
+	heavy_infantry = 0.3
 	horse_archers = 0.3
 }
 
@@ -44,8 +44,8 @@ levy_persian = {
 	default = no
 
 	archers = 0.7
-	heavy_infantry = 0.15
-	heavy_cavalry = 0.15
+	heavy_infantry = 0.2
+	heavy_cavalry = 0.1
 }
 
 

--- a/common/levy_templates/01_latin.txt
+++ b/common/levy_templates/01_latin.txt
@@ -7,23 +7,23 @@
 
 levy_italic = {
 	default = no
-	light_infantry = 0.6
-	light_cavalry = 0.1
+	light_infantry = 0.4
+	light_cavalry = 0.3
 	heavy_infantry = 0.3
 }
 
 levy_roman = {
 	default = no
 
-	light_infantry = 0.3
-	heavy_infantry = 0.5
-	light_cavalry = 0.2
+	light_infantry = 0.4
+	heavy_infantry = 0.3
+	light_cavalry = 0.3
 }
 
 levy_etruscan = {
 	default = no
 
-	light_infantry = 0.4	
+	light_infantry = 0.4
 	heavy_infantry = 0.3
 	light_cavalry = 0.3
 }
@@ -31,9 +31,9 @@ levy_etruscan = {
 levy_samnite = {
 	default = no
 
-	light_infantry = 0.5
+	light_infantry = 0.4
 	heavy_infantry = 0.3
-	light_cavalry = 0.2
+	light_cavalry = 0.3
 }
 
 levy_rhaetian = {

--- a/common/levy_templates/01_northwestafrica.txt
+++ b/common/levy_templates/01_northwestafrica.txt
@@ -8,7 +8,7 @@
 levy_numidian = {	#General Numidian
 	default = no
 
-	light_infantry = 0.35
-	warelephant = 0.3
+	light_infantry = 0.6
+	warelephant = 0.05
 	light_cavalry = 0.35
 }

--- a/common/levy_templates/01_scythosarmatian.txt
+++ b/common/levy_templates/01_scythosarmatian.txt
@@ -8,16 +8,16 @@
 levy_steppes = {
 	default = no
 
-	archers = 0.3
+	archers = 0.4
 	horse_archers = 0.3
-	light_cavalry = 0.4	
+	light_cavalry = 0.3
 }
 
 levy_sarmatian = {	#Sarmatians
 	default = no
 
-	archers = 0.45
-	light_cavalry = 0.25
+	archers = 0.4
+	light_cavalry = 0.3
 	horse_archers = 0.3
 }
 
@@ -25,15 +25,15 @@ levy_sarmatian = {	#Sarmatians
 levy_scythians = {
 	default = no
 
-	archers = 0.3
-	light_cavalry = 0.4
+	archers = 0.4
+	light_cavalry = 0.3
 	horse_archers = 0.3
 }
 
 levy_dahae = {
 	default = no
 
-	heavy_cavalry = 0.15
-	light_infantry = 0.7
-	horse_archers = 0.15
+	heavy_cavalry = 0.1
+	light_infantry = 0.6
+	horse_archers = 0.3
 }

--- a/common/levy_templates/01_south_levantine.txt
+++ b/common/levy_templates/01_south_levantine.txt
@@ -8,23 +8,23 @@
 levy_arabian = {	#General Arabian
 	default = no
 
-	light_infantry = 0.3
-	camels = 0.4
+	light_infantry = 0.4
+	camels = 0.3
 	horse_archers = 0.3
 }
 
 levy_south_arabian = {	#Yemeni
 	default = no
 
-	heavy_cavalry = 0.3
-	light_infantry = 0.4
+	heavy_cavalry = 0.1
+	light_infantry = 0.6
 	camels = 0.3
 }
 
 levy_hadrami = {	#Hadramut
 	default = no
 
-	light_infantry = 0.35
-	heavy_cavalry = 0.3
-	camels = 0.35
+	light_infantry = 0.6
+	heavy_cavalry = 0.1
+	camels = 0.3
 }

--- a/common/levy_templates/01_tibetan.txt
+++ b/common/levy_templates/01_tibetan.txt
@@ -9,6 +9,6 @@ levy_tibetan = {
 	default = no
 
 	light_infantry = 0.7
-	heavy_infantry = 0.2
-	warelephant = 0.1
+	heavy_infantry = 0.25
+	warelephant = 0.05
 }

--- a/common/levy_templates/01_west_levantine.txt
+++ b/common/levy_templates/01_west_levantine.txt
@@ -16,15 +16,15 @@ levy_west_levantine = {	#Levantine states
 levy_punic = {	#Punic states
 	default = no
 
-	light_infantry = 0.4
+	light_infantry = 0.65
 	light_cavalry = 0.3
-	warelephant = 0.3
+	warelephant = 0.05
 }
 
 levy_nabatean = {
 	default = no
-	
+
 	archers = 0.3
 	heavy_infantry = 0.3
-	light_cavalry = 0.4	
+	light_cavalry = 0.4
 }

--- a/common/modifiers/00_fighting_ground_modifiers.txt
+++ b/common/modifiers/00_fighting_ground_modifiers.txt
@@ -2,87 +2,89 @@
 	heavy_infantry_desert_combat_bonus = 0.25
 	heavy_infantry_plains_combat_bonus = 0.25
 	heavy_infantry_farmland_combat_bonus = 0.25
+	heavy_infantry_floodplain_combat_bonus = 0.25
 	heavy_infantry_oasis_combat_bonus = 0.25
 }
 
 light_mounted_terrain_boni = {
-
-	light_cavalry_plains_combat_bonus = 1.0
-	light_cavalry_mountain_combat_bonus = -0.25
+	light_cavalry_plains_combat_bonus = 1
+	light_cavalry_floodplain_combat_bonus = 1
+	light_cavalry_desert_combat_bonus = 1
+	light_cavalry_farmland_combat_bonus = 1
+	light_cavalry_oasis_combat_bonus = 1
+	light_cavalry_forest_combat_bonus = 0.25
 	light_cavalry_hills_combat_bonus = 0.25
-	light_cavalry_desert_combat_bonus = 1.0
 	light_cavalry_desert_hills_combat_bonus = 0.25
 	light_cavalry_marsh_combat_bonus = -0.25
 	light_cavalry_jungle_combat_bonus = -0.25
-	light_cavalry_farmland_combat_bonus = 1.0
-	light_cavalry_oasis_combat_bonus = 1.0
-	light_cavalry_forest_combat_bonus = 0.25
+	light_cavalry_mountain_combat_bonus = -0.25
 
-	horse_archers_plains_combat_bonus = 1.0
-	horse_archers_mountain_combat_bonus = -0.25
+	camels_desert_combat_bonus = 1.5
+	camels_oasis_combat_bonus = 1.5
+	camels_plains_combat_bonus = 0.75
+	camels_farmland_combat_bonus = 0.75
+	camels_floodplain_combat_bonus = 0.75
+	camels_desert_hills_combat_bonus = 0.5
+	camels_forest_combat_bonus = 0
+	camels_mountain_combat_bonus = -0.5
+	camels_marsh_combat_bonus = -0.5
+	camels_jungle_combat_bonus = -0.5
+
+	horse_archers_plains_combat_bonus = 1
+	horse_archers_floodplain_combat_bonus = 1
+	horse_archers_desert_combat_bonus = 1
+	horse_archers_oasis_combat_bonus = 1
+	horse_archers_farmland_combat_bonus = 1
 	horse_archers_hills_combat_bonus = 0.25
-	horse_archers_desert_combat_bonus = 1.0
 	horse_archers_desert_hills_combat_bonus = 0.25
+	horse_archers_forest_combat_bonus = 0.25
 	horse_archers_marsh_combat_bonus = -0.25
 	horse_archers_jungle_combat_bonus = -0.25
-	horse_archers_farmland_combat_bonus = 1.0
-	horse_archers_oasis_combat_bonus = 1.0
-	horse_archers_forest_combat_bonus = 0.25
+	horse_archers_mountain_combat_bonus = -0.25
 }
 
 heavy_mounted_terrain_boni = {
-
-	heavy_cavalry_plains_combat_bonus = 1.0
-	heavy_cavalry_mountain_combat_bonus = -0.25
+	heavy_cavalry_plains_combat_bonus = 1
+	heavy_cavalry_desert_combat_bonus = 1
+	heavy_cavalry_farmland_combat_bonus = 1
+	heavy_cavalry_floodplain_combat_bonus = 1
+	heavy_cavalry_oasis_combat_bonus = 1
 	heavy_cavalry_hills_combat_bonus = 0.25
-	heavy_cavalry_desert_combat_bonus = 1.0
 	heavy_cavalry_desert_hills_combat_bonus = 0.25
+	heavy_cavalry_forest_combat_bonus = 0.25
+	heavy_cavalry_mountain_combat_bonus = -0.25
 	heavy_cavalry_marsh_combat_bonus = -0.25
 	heavy_cavalry_jungle_combat_bonus = -0.25
-	heavy_cavalry_farmland_combat_bonus = 1.0
-	heavy_cavalry_oasis_combat_bonus = 1.0
-	heavy_cavalry_forest_combat_bonus = 0.25
 
-	camels_plains_combat_bonus = 0.75
-	camels_mountain_combat_bonus = -0.50
-	camels_desert_combat_bonus = 1.50
-	camels_desert_hills_combat_bonus = 0.50
-	camels_marsh_combat_bonus = -0.50
-	camels_jungle_combat_bonus = -0.50
-	camels_farmland_combat_bonus = 0.75
-	camels_oasis_combat_bonus = 1.50
-	camels_forest_combat_bonus = 0.0
-
-	warelephant_plains_combat_bonus = 1.0
+	warelephant_plains_combat_bonus = 1
+	warelephant_desert_combat_bonus = 1
+	warelephant_farmland_combat_bonus = 1
+	warelephant_floodplain_combat_bonus = 1
+	warelephant_oasis_combat_bonus = 1
 	warelephant_hills_combat_bonus = 0.25
-	warelephant_desert_combat_bonus = 1.0
 	warelephant_desert_hills_combat_bonus = 0.25
-	warelephant_marsh_combat_bonus = -0.50
-	warelephant_mountain_combat_bonus = -0.50
-	warelephant_jungle_combat_bonus = 0.50
-	warelephant_farmland_combat_bonus = 1.0
-	warelephant_oasis_combat_bonus = 1.0
 	warelephant_forest_combat_bonus = 0.25
+	warelephant_jungle_combat_bonus = 0.5
+	warelephant_marsh_combat_bonus = -0.5
+	warelephant_mountain_combat_bonus = -0.5
 }
 
 naval_terrain_boni = {
-
 	liburnian_riverine_terrain_combat_bonus = 0.25
-	trireme_riverine_terrain_combat_bonus = 0.15
-	hexere_riverine_terrain_combat_bonus = -0.1
-	octere_riverine_terrain_combat_bonus = -0.2
-	mega_galley_riverine_terrain_combat_bonus = -0.3
-
-	liburnian_ocean_combat_bonus = -0.2
-	hexere_ocean_combat_bonus = 0.15
-	octere_ocean_combat_bonus = 0.2
-	mega_galley_ocean_combat_bonus = 0.25
-}
-
-INR_Tributary_Terrain = {
 	liburnian_tributary_terrain_combat_bonus = 0.5
+	liburnian_ocean_combat_bonus = -0.2
+
+	trireme_riverine_terrain_combat_bonus = 0.15
 	trireme_tributary_terrain_combat_bonus = 0.3
+
+	hexere_ocean_combat_bonus = 0.15
+	hexere_riverine_terrain_combat_bonus = -0.1
 	hexere_tributary_terrain_combat_bonus = -0.15
+
+	octere_ocean_combat_bonus = 0.2
+	octere_riverine_terrain_combat_bonus = -0.2
 	octere_tributary_terrain_combat_bonus = -0.3
-	mega_galley_tributary_terrain_combat_bonus = -0.5
+
+	mega_galley_ocean_combat_bonus = 0.25
+	mega_galley_riverine_terrain_combat_bonus = -0.3
 }


### PR DESCRIPTION
* updates levy templates to balance HC and WE in templates
* HC costs about 60% more than HI, and that's where the balance point is at, so we will cap the template at 60% of HI (30% max) which is around 10% (with some rounding to make the math easier). WE are stronger yet than HC, so they are capped at 5%. I distributed the remaining ratio among the lower tier options